### PR TITLE
add wait for docker script [tag/2.310.0]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN apt-get update \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 
+COPY wait_for_docker_then_run.sh /usr/local/bin/wait_for_docker_then_run.sh
+
 USER runner

--- a/wait_for_docker_then_run.sh
+++ b/wait_for_docker_then_run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Wait for docker socket to exist.
+
+docker_socket=/run/docker/docker.sock
+count=0
+
+while [[ ! -S "${docker_socket}" ]]
+do
+    echo "Waiting for ${docker_socket}"
+    sleep 1
+
+    count=$((count+1))
+    if [[ ${count} -gt 60 ]]
+    then
+        echo "Timed out waiting for docker socket"
+        exit 1
+    fi
+done
+
+/home/runner/run.sh


### PR DESCRIPTION
The gha-runner-scale-set uses a DinD sidecar container.  Sometimes the actions container fails to connect to docker. It appears to be a timing issue, the DinD container isn't finished with its start up.

Add small script to wait for the docker socket file to exist. Times out if it takes over 