### PR TITLE
Fix tag logic for renovate-bot PRs.

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -24,11 +24,14 @@ jobs:
       env:
         MESSAGE: ${{ github.event.head_commit.message }}
       run: |
+        # look for sting like "[tag/v2.312.0]" in commit message.
         regex=".*\[tag/(.*)\].*"
 
         if [[ "${MESSAGE}" =~ $regex ]]
         then
-            tag=${BASH_REMATCH[1]}
+            tag="${BASH_REMATCH[1]}"
+            # remove v prefix if it exists.
+            tag="${tag/#v/}"
             echo -n "Found tag: ${tag}"
             git tag --force "${tag}"
             git push --tags --force

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -32,7 +32,7 @@ jobs:
             tag="${BASH_REMATCH[1]}"
             # remove v prefix if it exists.
             tag="${tag/#v/}"
-            echo -n "Found tag: ${tag}"
+            echo "Found tag: ${tag}"
             git tag --force "${tag}"
             git push --tags --force
         else


### PR DESCRIPTION
Renovate bot is prefixing a `v` in the `{{{prettyNewVersion}}}` part of the message.  We want to remove that `v` to match upstream tags.