### PR TITLE
Adding support for multiarch builds

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -3,9 +3,8 @@ name: build-and-publish
 
 on:
   push:
-    tags:
-    - '*.*.*'
-  pull_request: {}
+    branches:
+    - 'main'
 
 env:
   DOCKER_ORG: mobilecoin
@@ -17,15 +16,37 @@ jobs:
     - name: Checkout
       uses: mobilecoinofficial/gh-actions/checkout@v0
 
-    - name: Build/Publish Image
-      uses: mobilecoinofficial/gh-actions/docker@v0
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3.2.0
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3.6.1
+
+    - name: Cache Docker layers
+      uses: actions/cache@0v4.0.2
       with:
-        dockerfile: ./Dockerfile
-        flavor: latest=true
-        images: mobilecoin/gha-runner
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-        push: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3.3.0
+      with:
+        username: ${{ secrets.DOCKERHUB_TOKEN }}
+        password: ${{ secrets.DOCKERHUB_USERNAME }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v6.5.0
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
         tags: |
-          type=semver,pattern={{version}},priority=20
-          type=sha,priority=10
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
+          mobilecoin/gha-runner:latest
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+    - name: Move cache
+      run: |
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
## Details
This PR introduces an example of how to implement multi-architecture (multiarch) builds for gha-runner. Specifically, it addresses the need for ARM-based support in addition to the existing AMD builds. By incorporating ARM support, the usability and accessibility of the gha-runner project will significantly increase, reaching a broader range of devices and environments.

Current Architecture Support:

AMD (x86_64)
Requested Additional Architectures:

ARM (e.g., armv7, arm64)
Additional Information:

This PR is a preliminary implementation to demonstrate the addition of ARM architecture support. Please review the changes and provide feedback. If there are specific adjustments needed for integration with your build process or additional steps required, I am happy to assist in any way possible.

## Notes

The tags section has been updated to reflect the latest changes only because I couldn't find the gh-action that you are using for docker builds and tagging:
```yaml
tags: |
  mobilecoin/gha-runner:latest
```

Thank you for considering this enhancement. I look forward to your feedback and am eager to help with any further modifications needed to complete this implementation.

#18 