### PR TITLE
Include make, gcc-multilib, and g++-multilib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update \
   zip \
   zstd \
   make \
+  gcc-multilib \
+  g++-multilib \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
   unzip \
   zip \
   zstd \
+  make \
  && apt-get clean \
  && rm -r /var/lib/apt/lists/*
 


### PR DESCRIPTION
This PR includes make, gcc-multilib, and g++-multilib within the installed packages.